### PR TITLE
Ft/add security utils

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   postgres:
     image: postgres:latest
-    container_name: postgres_container
+    container_name: postgres_container_auth
     environment:
       POSTGRES_USER: test         # This creates the 'test' user by default
       POSTGRES_PASSWORD: 1234

--- a/src/main/java/org/spring/authenticationservice/Utils/SecurityUtil.java
+++ b/src/main/java/org/spring/authenticationservice/Utils/SecurityUtil.java
@@ -1,0 +1,53 @@
+package org.spring.authenticationservice.Utils;
+
+import org.spring.authenticationservice.model.UserPrinciple;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class SecurityUtil {
+
+    private Authentication getAuthentication(){
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
+    public String getUsername(){
+        Authentication authentication = getAuthentication();
+
+        if(authentication != null && authentication.getPrincipal() instanceof UserDetails){
+            return ((UserDetails)authentication.getPrincipal()).getUsername();
+        }
+
+        //if user is not authenticated
+        return null;
+    }
+
+    public Long getUserId(){
+        Authentication authentication = getAuthentication();
+
+        // Cast to UserPrinciple instead of UserDetails
+        if(authentication != null && authentication.getPrincipal() instanceof UserPrinciple){
+            return ((UserPrinciple) authentication.getPrincipal()).getUserId();
+        }
+        return null;
+    }
+
+    public List<String> getRoles(){
+        Authentication authentication = getAuthentication();
+
+        if(authentication != null && authentication.getPrincipal() instanceof UserPrinciple){
+            // Extract roles as strings
+            return ((UserPrinciple) authentication.getPrincipal()).getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority) // Get role name
+                    .collect(Collectors.toList());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/spring/authenticationservice/model/UserPrinciple.java
+++ b/src/main/java/org/spring/authenticationservice/model/UserPrinciple.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
 
 public class UserPrinciple implements UserDetails {
@@ -18,7 +19,9 @@ public class UserPrinciple implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singleton(new SimpleGrantedAuthority("USER"));
+        return user.getRoles().stream()
+                .map(role -> new SimpleGrantedAuthority(role.getName())) // Assuming Role has a 'name' field
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -29,6 +32,10 @@ public class UserPrinciple implements UserDetails {
     @Override
     public String getUsername() {
         return user.getEmail();
+    }
+
+    public Long getUserId(){
+        return user.getId();
     }
 
     @Override


### PR DESCRIPTION
This pull request Closes #23  and added several changes to the `authenticationservice` module to enhance security utilities and user principle handling. The most important changes include the addition of a new utility class for security operations, modifications to the `UserPrinciple` class to support roles and user IDs, and an update to the Docker Compose configuration.

### Security Utilities Enhancements:
* [`src/main/java/org/spring/authenticationservice/Utils/SecurityUtil.java`](diffhunk://#diff-37a343800d7df5dd637674d72037dff28b30dbd114e38d529869a8e7dd49b588R1-R53): Added a new `SecurityUtil` class to provide utility methods for retrieving the username, user ID, and roles of the authenticated user.

### UserPrinciple Class Improvements:
* [`src/main/java/org/spring/authenticationservice/model/UserPrinciple.java`](diffhunk://#diff-43b63fe4011a076e4d1be76ddb77e240c7b89b0c7e4c7adf0fe9a17f1a9584edL21-R24): Modified the `getAuthorities` method to return roles from the user object, assuming the `Role` class has a `name` field.
* [`src/main/java/org/spring/authenticationservice/model/UserPrinciple.java`](diffhunk://#diff-43b63fe4011a076e4d1be76ddb77e240c7b89b0c7e4c7adf0fe9a17f1a9584edR37-R40): Added a new `getUserId` method to return the user ID.

### Docker Compose Configuration Update:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L6-R6): Changed the `container_name` of the `postgres` service to `postgres_container_auth` to reflect the new authentication service context.